### PR TITLE
Fix Stripe curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ https://developer.paypal.com/docs/api/overview/#make-rest-api-calls
 
 ```
 
-curl https://api.stripe.com/v1/ 
-   -u token_here:
+curl https://api.stripe.com/v1/charges \
+  -u token_here:
 
    ```
 


### PR DESCRIPTION
The original Stripe curl command wasn't copy + paste ready.

1.  Backslash was missing, preventing copy + paste
2.  You have to pick an Object as endpoint — I chose `balance`